### PR TITLE
Removed Null values from serialization to allow not setting a Size or…

### DIFF
--- a/src/main/java/io/camunda/operate/util/JsonUtils.java
+++ b/src/main/java/io/camunda/operate/util/JsonUtils.java
@@ -5,10 +5,8 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.*;
 
 import io.camunda.operate.dto.SearchResult;
 
@@ -25,6 +23,7 @@ public class JsonUtils {
         if (mapper == null) {
             mapper = new ObjectMapper();
             mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         }
         return mapper;
     }


### PR DESCRIPTION
I need the `size` to be not existent in the JSON sent - current it is 

```json
size: null
```

Which leads to no result being returned. I think this fixes it - but I struggled with the Grade Build to test it in my local Maven Project - so I would wait for a SNAPSHOT build via Github Action and test it then.

@chDame - could you have a quick look maybe? 