### PR TITLE
Throw proper exception on unauthenticated requests

### DIFF
--- a/src/main/java/io/camunda/operate/auth/SaasAuthentication.java
+++ b/src/main/java/io/camunda/operate/auth/SaasAuthentication.java
@@ -48,10 +48,7 @@ public class SaasAuthentication extends JwtAuthentication {
         httpPost.setEntity(new StringEntity(data));
 
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
-                if (response.getCode()>399) {
-                  throw new OperateException("Authentication error : "+response.getCode()+" "+response.getReasonPhrase());
-                }
+            try (CloseableHttpResponse response = CamundaOperateClient.execute(httpClient, httpPost)) {
                 JsonNode responseBody = JsonUtils.toJsonNode(response.getEntity().getContent());
                 String token = responseBody.get("access_token").asText();
 


### PR DESCRIPTION
@chDame WDYT?
Currently unauthenticated responses are swallowed - that's I think also the moment when the search returns null as the response content is empty on 40x responses (https://github.com/camunda-community-hub/camunda-operate-client-java/issues/18).