### PR TITLE
Adds Authorization header on request

### DIFF
--- a/src/main/java/io/camunda/operate/CamundaOperateClient.java
+++ b/src/main/java/io/camunda/operate/CamundaOperateClient.java
@@ -94,6 +94,7 @@ public class CamundaOperateClient {
     CloseableHttpResponse response = httpClient.execute(request);
     if (response.getCode()==401 && count<=2) {
     	authentication.authenticate(this);
+        request.setHeader(authHeader);
     	return execute(httpClient, request, ++count);
     }
     if (response.getCode()>399) {


### PR DESCRIPTION
Adds the new Authorisation header on the request when the request is failing with Http status code 401. In case of an Unauthorised response, the authentication is retried but the new header was not added on the request causing the first request to fail