### PR TITLE
fix: wrong content type in request

### DIFF
--- a/extension/java-client-operate/src/main/java/io/camunda/operate/auth/JwtAuthentication.java
+++ b/extension/java-client-operate/src/main/java/io/camunda/operate/auth/JwtAuthentication.java
@@ -72,7 +72,7 @@ public class JwtAuthentication implements Authentication {
 
   private HttpPost buildRequest() throws URISyntaxException {
     HttpPost httpPost = new HttpPost(jwtCredential.authUrl().toURI());
-    httpPost.addHeader("Content-Type", "application/json");
+    httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
     List<NameValuePair> formParams = new ArrayList<>();
     formParams.add(new BasicNameValuePair("grant_type", "client_credentials"));
     formParams.add(new BasicNameValuePair("client_id", jwtCredential.clientId()));


### PR DESCRIPTION
```
  private HttpPost buildRequest() throws URISyntaxException {
    HttpPost httpPost = new HttpPost(jwtCredential.authUrl().toURI());
    httpPost.addHeader("Content-Type", "application/json");
```

`application/json` causes `java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "io.camunda.operate.auth.TokenResponse.getExpiresIn()" is null`

should be `application/x-www-form-urlencoded`