### PR TITLE
fix: update default oidc auth url

### DIFF
--- a/extension/spring-boot-starter-camunda-operate/src/main/resources/operate-profiles/oidc.yaml
+++ b/extension/spring-boot-starter-camunda-operate/src/main/resources/operate-profiles/oidc.yaml
@@ -3,6 +3,6 @@ operate:
     profile: oidc
     enabled: true
     base-url: http://localhost:8081
-    auth-url: http://localhost:18080/auth/realms/camunda-platform/openid-connect/token
+    auth-url: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
     audience: operate-api
 

--- a/extension/spring-boot-starter-camunda-operate/src/test/java/io/camunda/operate/spring/OperateClientConfigurationPropertiesProfileOidcTest.java
+++ b/extension/spring-boot-starter-camunda-operate/src/test/java/io/camunda/operate/spring/OperateClientConfigurationPropertiesProfileOidcTest.java
@@ -27,7 +27,8 @@ public class OperateClientConfigurationPropertiesProfileOidcTest {
     assertThat(properties.enabled()).isEqualTo(true);
     assertThat(properties.authUrl())
         .isEqualTo(
-            URI.create("http://localhost:18080/auth/realms/camunda-platform/openid-connect/token")
+            URI.create(
+                    "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token")
                 .toURL());
   }
 }


### PR DESCRIPTION
I ran into an issue with the default config - the auth code was getting a 404 with the default docker-compose setup. Adding the missing URL part helped solve the issue.