### PR TITLE
Add oauth scope (for entra id)

### DIFF
--- a/extension/java-client-operate/src/main/java/io/camunda/operate/auth/JwtAuthentication.java
+++ b/extension/java-client-operate/src/main/java/io/camunda/operate/auth/JwtAuthentication.java
@@ -73,6 +73,7 @@ public class JwtAuthentication implements Authentication {
     formParams.add(new BasicNameValuePair("client_id", jwtCredential.clientId()));
     formParams.add(new BasicNameValuePair("client_secret", jwtCredential.clientSecret()));
     formParams.add(new BasicNameValuePair("audience", jwtCredential.audience()));
+    formParams.add(new BasicNameValuePair("scope", jwtCredential.scope()));
     httpPost.setEntity(new UrlEncodedFormEntity(formParams));
     return httpPost;
   }

--- a/extension/java-client-operate/src/main/java/io/camunda/operate/auth/JwtCredential.java
+++ b/extension/java-client-operate/src/main/java/io/camunda/operate/auth/JwtCredential.java
@@ -2,4 +2,5 @@ package io.camunda.operate.auth;
 
 import java.net.URL;
 
-public record JwtCredential(String clientId, String clientSecret, String audience, URL authUrl) {}
+public record JwtCredential(
+    String clientId, String clientSecret, String audience, URL authUrl, String scope) {}

--- a/extension/spring-boot-starter-camunda-operate/src/main/java/io/camunda/operate/spring/OperateClientConfiguration.java
+++ b/extension/spring-boot-starter-camunda-operate/src/main/java/io/camunda/operate/spring/OperateClientConfiguration.java
@@ -76,7 +76,8 @@ public class OperateClientConfiguration {
                 properties.clientId(),
                 properties.clientSecret(),
                 properties.audience(),
-                properties.authUrl()),
+                properties.authUrl(),
+                properties.scope()),
             new JacksonTokenResponseMapper(objectMapper));
       }
       default -> throw new IllegalStateException("Unsupported profile: " + properties.profile());

--- a/extension/spring-boot-starter-camunda-operate/src/main/java/io/camunda/operate/spring/OperateClientConfigurationProperties.java
+++ b/extension/spring-boot-starter-camunda-operate/src/main/java/io/camunda/operate/spring/OperateClientConfigurationProperties.java
@@ -19,6 +19,7 @@ public record OperateClientConfigurationProperties(
     String clientSecret,
     URL authUrl,
     String audience,
+    String scope,
     // saas auth properies
     String region,
     String clusterId) {


### PR DESCRIPTION
When using Entra ID as identity provider, we need to specify the correct scope when retrieving a token (see https://docs.camunda.io/docs/8.5/self-managed/setup/guides/connect-to-an-oidc-provider/)

I've added it to the java client and spring properties.