### PR TITLE
Add versionTag property to the ProcessDefinition

### DIFF
--- a/extension/java-client-operate/src/main/java/io/camunda/operate/model/ProcessDefinition.java
+++ b/extension/java-client-operate/src/main/java/io/camunda/operate/model/ProcessDefinition.java
@@ -6,6 +6,7 @@ public class ProcessDefinition {
   private Long version;
   private String bpmnProcessId;
   private String tenantId;
+  private String versionTag;
 
   public Long getKey() {
     return key;
@@ -45,5 +46,13 @@ public class ProcessDefinition {
 
   public void setTenantId(String tenantId) {
     this.tenantId = tenantId;
+  }
+
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public void setVersionTag(String versionTag) {
+    this.versionTag = versionTag;
   }
 }

--- a/extension/java-client-operate/src/main/java/io/camunda/operate/search/ProcessDefinitionFilterBuilder.java
+++ b/extension/java-client-operate/src/main/java/io/camunda/operate/search/ProcessDefinitionFilterBuilder.java
@@ -33,6 +33,11 @@ public class ProcessDefinitionFilterBuilder {
     return this;
   }
 
+  public ProcessDefinitionFilterBuilder versionTag(String versionTag) {
+    filter.setVersionTag(versionTag);
+    return this;
+  }
+
   public ProcessDefinitionFilter build() {
     return filter;
   }


### PR DESCRIPTION
In version 8.6, the new property versionTag has been added; however, it is missing in the ProcessDefinition POJO. This PR adds it to ProcessDefinition and to ProcessDefinitionFilterBuilder as well.